### PR TITLE
Tweak error messages to be more consistent, use C-style commenting

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -98,7 +98,8 @@ bool scanTokens(char* json_path, struct jpath_token tok[], int* tok_count) {
 
   while (*p != '\0') {
     if (i >= PARSE_BUF_LEN) {
-      zend_throw_exception(spl_ce_RuntimeException, "The query is too long. Token count exceeds PARSE_BUF_LEN.", 0);
+      zend_throw_exception_ex(spl_ce_RuntimeException,
+                              0, "The query is too long, token count exceeds maximum amount (%d)", PARSE_BUF_LEN);
       return false;
     }
 

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -134,39 +134,39 @@ void exec_slice(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* retur
   int range_end = tok->data.d_list.count > 1 ? tok->data.d_list.indexes[1] : INT_MAX;
   int range_step = tok->data.d_list.count > 2 ? tok->data.d_list.indexes[2] : 1;
 
-  // Zero-steps are not allowed, abort
+  /* Zero-steps are not allowed, abort */
   if (range_step == 0) {
     return;
   }
 
-  // Replace placeholder with actual value
+  /* Replace placeholder with actual value */
   if (range_start == INT_MAX) {
     range_start = range_step > 0 ? 0 : data_length - 1;
   }
-  // Indexing from the end of the list
+  /* Indexing from the end of the list */
   else if (range_start < 0) {
     range_start = data_length - abs(range_start);
   }
 
-  // Replace placeholder with actual value
+  /* Replace placeholder with actual value */
   if (range_end == INT_MAX) {
     range_end = range_step > 0 ? data_length : -1;
   }
-  // Indexing from the end of the list
+  /* Indexing from the end of the list */
   else if (range_end < 0) {
     range_end = data_length - abs(range_end);
   }
 
-  // Set suitable boundaries for start index
+  /* Set suitable boundaries for start index */
   range_start = range_start < -1 ? -1 : range_start;
   range_start = range_start > data_length ? data_length : range_start;
 
-  // Set suitable boundaries for end index
+  /* Set suitable boundaries for end index */
   range_end = range_end < -1 ? -1 : range_end;
   range_end = range_end > data_length ? data_length : range_end;
 
   if (range_step > 0) {
-    // Make sure that the range is sane so we don't end up in an infinite loop
+    /* Make sure that the range is sane so we don't end up in an infinite loop */
     if (range_start >= range_end) {
       return;
     }
@@ -180,7 +180,7 @@ void exec_slice(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* retur
       }
     }
   } else {
-    // Make sure that the range is sane so we don't end up in an infinite loop
+    /* Make sure that the range is sane so we don't end up in an infinite loop */
     if (range_start <= range_end) {
       return;
     }

--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -85,13 +85,13 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
           case '\0':
             /* The whole expression can end with a recursive descent operator, but not with a dot selector */
             if (*(*p - 2) != '.') {
-              raise_error("Dot selector must be followed by a node name or wildcard", json_path, *p - 1);
+              raise_error("Dot selector `.` must be followed by a node name or wildcard", json_path, *p - 1);
               return false;
             }
             return true;
           default:
             if (CUR_CHAR() == '"' || CUR_CHAR() == '\'') {
-              raise_error("Quoted node names must use the bracket notation [", json_path, *p);
+              raise_error("Quoted node names must use the bracket notation `[`", json_path, *p);
               return false;
             }
             extract_unbounded_literal(p, json_path, token);
@@ -113,7 +113,7 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
             EAT_WHITESPACE();
 
             if (CUR_CHAR() != ']') {
-              raise_error("Missing closing ] bracket", json_path, *p);
+              raise_error("Missing closing bracket `]`", json_path, *p);
               return false;
             }
             token->type = LEX_NODE;
@@ -152,7 +152,7 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
         } else if (CUR_CHAR() == '~') {
           token->type = LEX_RGXP;
         } else {
-          raise_error("Invalid character after '='. Valid values: '==', '!~'.", json_path, *p);
+          raise_error("Invalid character after `=`, valid values are `==` and `=~`", json_path, *p);
           return false;
         }
         NEXT_CHAR();
@@ -188,7 +188,7 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
         NEXT_CHAR();
 
         if (CUR_CHAR() != '&') {
-          raise_error("'And' operator must be double &&", json_path, *p);
+          raise_error("AND operator must be double ampersand `&&`", json_path, *p);
           return false;
         }
 
@@ -199,7 +199,7 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
         NEXT_CHAR();
 
         if (CUR_CHAR() != '|') {
-          raise_error("'Or' operator must be double ||", json_path, *p);
+          raise_error("OR operator must be double pipe `||`", json_path, *p);
           return false;
         }
 
@@ -254,7 +254,7 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
         NEXT_CHAR();
         break;
       default:
-        zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unrecognized token '%c' at position %ld", CUR_CHAR(),
+        zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unrecognized token `%c` at position %ld", CUR_CHAR(),
                                 (*p - json_path));
         return false;
     }
@@ -270,7 +270,7 @@ static bool extract_quoted_literal(char** p, char* json_path, struct jpath_token
   char* start = *p;
 
   for (; (CUR_CHAR() == '\'' || CUR_CHAR() == '"' || CUR_CHAR() == ' '); NEXT_CHAR()) {
-    // Find first occurrence
+    /* Find first occurrence of single or double quote */
     if (CUR_CHAR() == '\'' || CUR_CHAR() == '"') {
       quote_found = true;
       quote_type = CUR_CHAR();

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -76,10 +76,10 @@ bool build_parse_tree(PARSER_PARAMS, struct ast_node* head) {
         cur = ast_alloc_node(cur, AST_RECURSE);
         break;
       case LEX_CUR_NODE:
-        // noop
+        /* noop */
         break;
       case LEX_NODE:
-        // fall-through
+        /* fall-through */
         cur = ast_alloc_node(cur, AST_SELECTOR);
         cur->data.d_selector.val = CUR_TOKEN_LITERAL();
         cur->data.d_selector.len = CUR_TOKEN_LEN();
@@ -87,7 +87,7 @@ bool build_parse_tree(PARSER_PARAMS, struct ast_node* head) {
       case LEX_FILTER_START:
 
         if (*lex_idx == lex_tok_count - 1) { /* last token */
-          zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing filter end ]");
+          zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing filter end `]`");
           return false;
         }
 
@@ -118,7 +118,7 @@ bool build_parse_tree(PARSER_PARAMS, struct ast_node* head) {
         }
 
         if (*lex_idx == lex_tok_count - 1 || lex_tok[(*lex_idx) + 1].type != LEX_EXPR_END) { /* last token */
-          zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing filter end ]");
+          zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing filter end `]`");
           return false;
         }
 
@@ -170,22 +170,22 @@ static bool parse_filter_list(PARSER_PARAMS, struct ast_node* tok) {
     } else if (CUR_TOKEN() == LEX_CHILD_SEP) {
       if (sep_found == AST_INDEX_SLICE) {
         zend_throw_exception(spl_ce_RuntimeException,
-                             "Multiple filter list separators found [,:], only one type is allowed.", 0);
+                             "Multiple filter list separators `,` and `:` found, only one type is allowed", 0);
         return false;
       }
       tok->type = sep_found = AST_INDEX_LIST;
     } else if (CUR_TOKEN() == LEX_SLICE) {
       if (sep_found == AST_INDEX_LIST) {
         zend_throw_exception(spl_ce_RuntimeException,
-                             "Multiple filter list separators found [,:], only one type is allowed.", 0);
+                             "Multiple filter list separators `,` and `:` found, only one type is allowed", 0);
         return false;
       }
 
       tok->type = sep_found = AST_INDEX_SLICE;
 
       slice_count++;
-      // [:a] => [0:a]
-      // [a::] => [a:0:]
+      /* [:a] => [0:a] */
+      /* [a::] => [a:0:] */
       if (slice_count > tok->data.d_list.count) {
         if (slice_count == 1) {
           tok->data.d_list.indexes[tok->data.d_list.count] = INT_MAX;
@@ -198,14 +198,14 @@ static bool parse_filter_list(PARSER_PARAMS, struct ast_node* tok) {
       long idx = 0;
 
       if (!numeric_to_long(CUR_TOKEN_LITERAL(), CUR_TOKEN_LEN(), &idx)) {
-        zend_throw_exception(spl_ce_RuntimeException, "Unable to parse filter index value.", 0);
+        zend_throw_exception(spl_ce_RuntimeException, "Unable to parse filter index value", 0);
         return false;
       }
 
       tok->data.d_list.indexes[tok->data.d_list.count] = idx;
       tok->data.d_list.count++;
     } else {
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unexpected token in filter: %s", LEX_STR[CUR_TOKEN()]);
+      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unexpected token `%s` in filter", LEX_STR[CUR_TOKEN()]);
       return false;
     }
   }
@@ -216,7 +216,7 @@ static struct ast_node* parse_expression(PARSER_PARAMS) {
   CONSUME_TOKEN(); /* LEX_EXPR_START */
 
   if (CUR_TOKEN() != LEX_PAREN_OPEN) {
-    zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing opening paren (");
+    zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing opening paren `(`");
     return NULL;
   }
 
@@ -337,7 +337,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
   if (CUR_TOKEN() == LEX_LITERAL_NUMERIC) {
     struct ast_node* ret = ast_alloc_node(NULL, AST_DOUBLE);
     if (!make_numeric_node(ret, CUR_TOKEN_LITERAL(), CUR_TOKEN_LEN())) {
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unable to parse numeric.");
+      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unable to parse numeric");
       return NULL;
     }
     CONSUME_TOKEN();
@@ -352,7 +352,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
     } else if (strncasecmp("false", CUR_TOKEN_LITERAL(), 5) == 0) {
       ret->data.d_literal.value_bool = false;
     } else {
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Expected `true` or `false` for boolean token.");
+      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Expected `true` or `false` for boolean token");
       return NULL;
     }
     CONSUME_TOKEN();
@@ -383,7 +383,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
 
       if (CUR_TOKEN() == LEX_WILD_CARD) {
         free_ast_nodes(ret);
-        zend_throw_exception(spl_ce_RuntimeException, "Multiplying node values is not supported.", 0);
+        zend_throw_exception(spl_ce_RuntimeException, "Multiplying node values is not supported", 0);
         return NULL;
       }
     }
@@ -423,7 +423,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
       return expr;
     } else {
       free_ast_nodes(expr);
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing closing paren )");
+      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing closing paren `)`");
       return NULL;
     }
   }
@@ -456,7 +456,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
     return head.next;
   }
 
-  zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Filter expressions may not be empty.");
+  zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Filter expressions may not be empty");
 
   return NULL;
 }
@@ -528,13 +528,13 @@ bool validate_parse_tree(struct ast_node* head) {
         }
         if (!validate_root_next(cur->next)) {
           zend_throw_exception(spl_ce_RuntimeException,
-                               "$ must be followed by a child selector, filter or recurse element.", 0);
+                               "Root `$` must be followed by a child selector, filter or recurse element", 0);
           return false;
         }
         break;
       case AST_EXPR:
         if (cur->data.d_expression.head == NULL) {
-          zend_throw_exception(spl_ce_RuntimeException, "Filter expressions may not be empty.", 0);
+          zend_throw_exception(spl_ce_RuntimeException, "Filter expressions may not be empty", 0);
           return false;
         } else if (!validate_expression_head(cur->data.d_expression.head)) {
           zend_throw_exception(spl_ce_RuntimeException, "Invalid expression.", 0);
@@ -545,7 +545,7 @@ bool validate_parse_tree(struct ast_node* head) {
         if (cur->next == NULL || (cur->next->type == AST_SELECTOR && cur->next->data.d_selector.len == 0)) {
           zend_throw_exception(
               spl_ce_RuntimeException,
-              "Recursive descent operator (..) must be followed by a child selector, filter or wildcard.", 0);
+              "Recursive descent operator `..` must be followed by a child selector, filter or wildcard", 0);
           return false;
         }
         break;
@@ -634,12 +634,12 @@ static bool is_operator(lex_token type) {
 
 bool sanity_check(struct jpath_token lex_token[], int lex_tok_count) {
   if (lex_tok_count == 0) {
-    zend_throw_exception(spl_ce_RuntimeException, "The JSONpath contains no valid elements", 0);
+    zend_throw_exception(spl_ce_RuntimeException, "JSONPath expression contains no valid elements", 0);
     return false;
   }
 
   if (lex_token[0].type != LEX_ROOT) {
-    zend_throw_exception(spl_ce_RuntimeException, "JSONpath must start with a root $", 0);
+    zend_throw_exception(spl_ce_RuntimeException, "JSONPath expression must start with a root `$`", 0);
     return false;
   }
 

--- a/tests/comparison_bracket_notation/030.phpt
+++ b/tests/comparison_bracket_notation/030.phpt
@@ -16,7 +16,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position %d in %s
+Fatal error: Uncaught RuntimeException: Missing closing bracket `]` at position %d in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_bracket_notation/036.phpt
+++ b/tests/comparison_bracket_notation/036.phpt
@@ -24,7 +24,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position 7 in %s
+Fatal error: Uncaught RuntimeException: Missing closing bracket `]` at position 7 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_bracket_notation/037.phpt
+++ b/tests/comparison_bracket_notation/037.phpt
@@ -23,8 +23,8 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing filter end ] in %s037.php:%d
+Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
 Stack trace:
-#0 %s037.php(%d): JsonPath->find(Array, '$[two.some]')
-#1 {main}
-  thrown in %s037.php on line %d
+%s
+%s
+%s

--- a/tests/comparison_bracket_notation/046.phpt
+++ b/tests/comparison_bracket_notation/046.phpt
@@ -16,7 +16,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token 'k' at position 2 in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `k` at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/003.phpt
+++ b/tests/comparison_dot_notation/003.phpt
@@ -21,7 +21,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token 'k' at position 3 in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `k` at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/022.phpt
+++ b/tests/comparison_dot_notation/022.phpt
@@ -17,7 +17,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation [ at position 2 in %s
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/023.phpt
+++ b/tests/comparison_dot_notation/023.phpt
@@ -35,7 +35,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation [ at position 3 in %s
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/024.phpt
+++ b/tests/comparison_dot_notation/024.phpt
@@ -18,7 +18,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Dot selector must be followed by a node name or wildcard at position 1 in %s
+Fatal error: Uncaught RuntimeException: Dot selector `.` must be followed by a node name or wildcard at position 1 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/035.phpt
+++ b/tests/comparison_dot_notation/035.phpt
@@ -17,7 +17,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation [ at position 2 in %s
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/036.phpt
+++ b/tests/comparison_dot_notation/036.phpt
@@ -35,7 +35,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation [ at position 3 in %s
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/037.phpt
+++ b/tests/comparison_dot_notation/037.phpt
@@ -20,7 +20,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation [ at position 2 in %s
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/048.phpt
+++ b/tests/comparison_dot_notation/048.phpt
@@ -17,7 +17,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token 'a' at position 1 in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `a` at position 1 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/049.phpt
+++ b/tests/comparison_dot_notation/049.phpt
@@ -16,7 +16,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: JSONpath must start with a root $ in %s
+Fatal error: Uncaught RuntimeException: JSONPath expression must start with a root `$` in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/050.phpt
+++ b/tests/comparison_dot_notation/050.phpt
@@ -16,7 +16,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token 'k' at position 0 in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `k` at position 0 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/004.phpt
+++ b/tests/comparison_filter/004.phpt
@@ -30,7 +30,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token '+' at position 9 in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `+` at position 9 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/019.phpt
+++ b/tests/comparison_filter/019.phpt
@@ -30,7 +30,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token '/' at position 9 in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `/` at position 9 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/022.phpt
+++ b/tests/comparison_filter/022.phpt
@@ -21,7 +21,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Filter expressions may not be empty. in %s
+Fatal error: Uncaught RuntimeException: Filter expressions may not be empty in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/049.phpt
+++ b/tests/comparison_filter/049.phpt
@@ -30,7 +30,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token 'i' at position 8 in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `i` at position 8 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/050.phpt
+++ b/tests/comparison_filter/050.phpt
@@ -44,7 +44,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token 'i' at position 6 in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `i` at position 6 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/053.phpt
+++ b/tests/comparison_filter/053.phpt
@@ -30,7 +30,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Multiplying node values is not supported. in %s
+Fatal error: Uncaught RuntimeException: Multiplying node values is not supported in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/058.phpt
+++ b/tests/comparison_filter/058.phpt
@@ -33,7 +33,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token '/' at position 12 in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `/` at position 12 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/061.phpt
+++ b/tests/comparison_filter/061.phpt
@@ -81,7 +81,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Invalid character after '='. Valid values: '==', '!~'. at position 10 in %s
+Fatal error: Uncaught RuntimeException: Invalid character after `=`, valid values are `==` and `=~` at position 10 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/066.phpt
+++ b/tests/comparison_filter/066.phpt
@@ -81,7 +81,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Invalid character after '='. Valid values: '==', '!~'. at position 12 in %s
+Fatal error: Uncaught RuntimeException: Invalid character after `=`, valid values are `==` and `=~` at position 12 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/074.phpt
+++ b/tests/comparison_filter/074.phpt
@@ -81,7 +81,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing opening paren ( in %s
+Fatal error: Uncaught RuntimeException: Missing opening paren `(` in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_misc/001.phpt
+++ b/tests/comparison_misc/001.phpt
@@ -17,7 +17,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: The JSONpath contains no valid elements in %s
+Fatal error: Uncaught RuntimeException: JSONPath expression contains no valid elements in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_misc/002.phpt
+++ b/tests/comparison_misc/002.phpt
@@ -18,7 +18,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token 'k' at position 2 in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `k` at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_misc/003.phpt
+++ b/tests/comparison_misc/003.phpt
@@ -20,8 +20,8 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing filter end ] in %s003.php:%d
+Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
 Stack trace:
-#0 %s003.php(%d): JsonPath->find(Array, '$[(@.length-1)]')
-#1 {main}
-  thrown in %s003.php on line %d
+%s
+%s
+%s

--- a/tests/comparison_recursive_descent/001.phpt
+++ b/tests/comparison_recursive_descent/001.phpt
@@ -24,7 +24,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in %s
+Fatal error: Uncaught RuntimeException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_recursive_descent/002.phpt
+++ b/tests/comparison_recursive_descent/002.phpt
@@ -23,7 +23,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in %s
+Fatal error: Uncaught RuntimeException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_union/012.phpt
+++ b/tests/comparison_union/012.phpt
@@ -25,7 +25,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Multiple filter list separators found [,:], only one type is allowed. in %s
+Fatal error: Uncaught RuntimeException: Multiple filter list separators `,` and `:` found, only one type is allowed in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_union/013.phpt
+++ b/tests/comparison_union/013.phpt
@@ -20,7 +20,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Multiple filter list separators found [,:], only one type is allowed. in %s
+Fatal error: Uncaught RuntimeException: Multiple filter list separators `,` and `:` found, only one type is allowed in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_union/015.phpt
+++ b/tests/comparison_union/015.phpt
@@ -20,8 +20,8 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing filter end ] in %s015.php:%d
+Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
 Stack trace:
-#0 %s015.php(%d): JsonPath->find(Array, '$[*,1]')
-#1 {main}
-  thrown in %s015.php on line %d
+%s
+%s
+%s

--- a/tests/lex_errs/001.phpt
+++ b/tests/lex_errs/001.phpt
@@ -9,7 +9,7 @@ $jsonPath = new JsonPath();
 
 $jsonPath->find([], "$.testl['test'");
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position 14 in %s
+Fatal error: Uncaught RuntimeException: Missing closing bracket `]` at position 14 in %s
 Stack trace:
 %s
 %s

--- a/tests/lex_errs/002.phpt
+++ b/tests/lex_errs/002.phpt
@@ -9,7 +9,7 @@ $jsonPath = new JsonPath();
 
 $jsonPath->find([], '$.testl["test"');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position 14 in %s
+Fatal error: Uncaught RuntimeException: Missing closing bracket `]` at position 14 in %s
 Stack trace:
 %s
 %s

--- a/tests/lex_errs/004.phpt
+++ b/tests/lex_errs/004.phpt
@@ -9,7 +9,7 @@ $jsonPath = new JsonPath();
 
 $jsonPath->find([], '$.book[?(@.id.isbn == "684832674" & @.author == "Herman Melville")]');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: 'And' operator must be double && at position 35 in %s
+Fatal error: Uncaught RuntimeException: AND operator must be double ampersand `&&` at position 35 in %s
 Stack trace:
 %s
 %s

--- a/tests/lex_errs/005.phpt
+++ b/tests/lex_errs/005.phpt
@@ -9,7 +9,7 @@ $jsonPath = new JsonPath();
 
 $jsonPath->find([], '$.book[?(@.id.isbn == "684832674" | @.author == "Herman Melville")]');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: 'Or' operator must be double || at position 35 in %s
+Fatal error: Uncaught RuntimeException: OR operator must be double pipe `||` at position 35 in %s
 Stack trace:
 %s
 %s

--- a/tests/overflow/002.phpt
+++ b/tests/overflow/002.phpt
@@ -14,4 +14,4 @@ try {
     echo get_class($e) . ": " . $e->getMessage();
 }
 --EXPECT--
-RuntimeException: The query is too long. Token count exceeds PARSE_BUF_LEN.
+RuntimeException: The query is too long, token count exceeds maximum amount (50)

--- a/tests/parse_errs/001.phpt
+++ b/tests/parse_errs/001.phpt
@@ -9,7 +9,7 @@ $jsonPath = new JsonPath();
 
 $jsonPath->find([], '$.book[');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing filter end ] in %s
+Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
 Stack trace:
 %s
 %s

--- a/tests/parse_errs/002.phpt
+++ b/tests/parse_errs/002.phpt
@@ -9,7 +9,7 @@ $jsonPath = new JsonPath();
 
 $jsonPath->find([], '$.store.book[?(@.author == "Evelyn Waugh"');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing paren ) in %s
+Fatal error: Uncaught RuntimeException: Missing closing paren `)` in %s
 Stack trace:
 %s
 %s


### PR DESCRIPTION
I suggest single-sentence error messages without trailing period, so that the exception messages look nicer. I've also changed all expression characters in the error messages to be wrapped with backticks. Example:

Before:

```
Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in [...]
```

After:

```
Fatal error: Uncaught RuntimeException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard in [...] 
```

All code comments changed to use C-style commenting `/* ... */`.