### PR TITLE
Handle escaped quotes in string literals

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -34,18 +34,23 @@ PHP_METHOD(JsonPath, find) {
 
   char* j_path;
   size_t j_path_len;
+  char* j_path_work_copy;
   zval* search_target;
 
   if (zend_parse_parameters(ZEND_NUM_ARGS(), "as", &search_target, &j_path, &j_path_len) == FAILURE) {
     return;
   }
 
+  /* Keep the original parameter untouched for the stack trace and instead work with a copy */
+  /* that might be modified during processing, e.g. due to escaped quotes in string literals */
+  j_path_work_copy = strdup(j_path);
+
   /* tokenize JSON-path string */
 
   struct jpath_token lex_tok[PARSE_BUF_LEN];
   int lex_tok_count = 0;
 
-  if (!scanTokens(j_path, lex_tok, &lex_tok_count)) {
+  if (!scanTokens(j_path_work_copy, lex_tok, &lex_tok_count)) {
     return;
   }
 

--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -288,8 +288,23 @@ static bool extract_quoted_literal(char** p, char* json_path, struct jpath_token
   token->val = *p;
   token->type = LEX_LITERAL;
 
-  for (; CUR_CHAR() != '\0' && CUR_CHAR() != quote_type && *(*p - 1) != '\\'; NEXT_CHAR()) {
+  while (CUR_CHAR() != '\0') {
+    /* Find escaped quotes and backslashes and remove the escaping by shifting the string */
+    if (CUR_CHAR() == '\\') {
+      if (PEEK_CHAR() == '\\' || PEEK_CHAR() == '\'' || PEEK_CHAR() == '"') {
+        memmove(*p, *p + 1, strlen(*p));
+        token->len++;
+        NEXT_CHAR();
+        continue;
+      }
+    }
+
+    if (CUR_CHAR() == quote_type) {
+      break;
+    }
+
     token->len++;
+    NEXT_CHAR();
   }
 
   NEXT_CHAR();

--- a/tests/comparison_bracket_notation/025.phpt
+++ b/tests/comparison_bracket_notation/025.phpt
@@ -10,7 +10,7 @@ $data = [
 ];
 
 $jsonPath = new JsonPath();
-$result = $jsonPath->find($data, "$['\\']");
+$result = $jsonPath->find($data, "$['\\\\']");
 
 echo "Assertion 1\n";
 var_dump($result);

--- a/tests/comparison_bracket_notation/026.phpt
+++ b/tests/comparison_bracket_notation/026.phpt
@@ -10,7 +10,7 @@ $data = [
 ];
 
 $jsonPath = new JsonPath();
-$result = $jsonPath->find($data, '$["\'"]');
+$result = $jsonPath->find($data, "$['\\'']");
 
 echo "Assertion 1\n";
 var_dump($result);

--- a/tests/comparison_bracket_notation/029.phpt
+++ b/tests/comparison_bracket_notation/029.phpt
@@ -21,5 +21,3 @@ array(1) {
   [0]=>
   int(42)
 }
---XFAIL--
-Requires changes to accommodate for quoted single-quotes


### PR DESCRIPTION
The change in `extract_quoted_literal()` is to unescape quotes inside the string. It's invasive on the JSONPath expression string – removing escape-backslashes by shifting the whole remaining string one character to the left. I'm therefore taking a copy of the original parameter in `jsonpath.c`, so that the stack trace shows the original data without null characters or other oddities.

Not sure if this is the best way to do it, but everything else I tried basically failed due to string length mismatches, incorrect pointers etc.

Related to https://github.com/supermetrics-public/php-ext-jsonpath/issues/55.