### PR TITLE
Implement support for current object

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -103,8 +103,8 @@ bool scanTokens(char* json_path, struct jpath_token tok[], int* tok_count) {
 
   while (*p != '\0') {
     if (i >= PARSE_BUF_LEN) {
-      zend_throw_exception_ex(spl_ce_RuntimeException,
-                              0, "The query is too long, token count exceeds maximum amount (%d)", PARSE_BUF_LEN);
+      zend_throw_exception_ex(spl_ce_RuntimeException, 0,
+                              "The query is too long, token count exceeds maximum amount (%d)", PARSE_BUF_LEN);
       return false;
     }
 

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -18,6 +18,7 @@ typedef enum {
 enum ast_type {
   AST_AND,
   AST_BOOL,
+  AST_CUR_NODE,
   AST_DOUBLE,
   AST_EQ,
   AST_EXPR,

--- a/tests/comparison_filter/016.phpt
+++ b/tests/comparison_filter/016.phpt
@@ -53,5 +53,3 @@ array(11) {
   [10]=>
   bool(true)
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_filter/024.phpt
+++ b/tests/comparison_filter/024.phpt
@@ -29,5 +29,3 @@ array(1) {
   [0]=>
   int(42)
 }
---XFAIL--
-Requires more work on filter expressions


### PR DESCRIPTION
I am working on #63. Incidentally, fixing `tests/comparison_filter/024.phpt` (which is part of #63) also fixed `tests/comparison_filter/016.phpt`, which is assigned to you in #55 @crocodele.