### PR TITLE
Issue #63 - Support filters inside expressions, fix negative index bug

### DIFF
--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -113,11 +113,12 @@ void exec_recursive_descent(zval* arr_head, zval* arr_cur, struct ast_node* tok,
 
 void exec_index_filter(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
   for (int i = 0; i < tok->data.d_list.count; i++) {
-    if (tok->data.d_list.indexes[i] < 0) {
-      tok->data.d_list.indexes[i] = zend_hash_num_elements(HASH_OF(arr_cur)) - abs(tok->data.d_list.indexes[i]);
+    int index = tok->data.d_list.indexes[i];
+    if (index < 0) {
+      index = zend_hash_num_elements(HASH_OF(arr_cur)) - abs(index);
     }
     zval* data;
-    if ((data = zend_hash_index_find(HASH_OF(arr_cur), tok->data.d_list.indexes[i])) != NULL) {
+    if ((data = zend_hash_index_find(HASH_OF(arr_cur), index)) != NULL) {
       copy_result_or_continue(arr_head, data, tok, return_value);
       if (break_if_result_found(return_value)) {
         break;

--- a/tests/comparison_bracket_notation/037.phpt
+++ b/tests/comparison_bracket_notation/037.phpt
@@ -19,11 +19,10 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$[two.some]");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
+Fatal error: Uncaught RuntimeException: Unexpected filter element in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/013.phpt
+++ b/tests/comparison_filter/013.phpt
@@ -44,5 +44,3 @@ array(2) {
     int(2)
   }
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_filter/014.phpt
+++ b/tests/comparison_filter/014.phpt
@@ -33,5 +33,3 @@ array(1) {
     string(1) "b"
   }
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_filter/015.phpt
+++ b/tests/comparison_filter/015.phpt
@@ -33,5 +33,3 @@ array(1) {
     string(1) "b"
   }
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_misc/003.phpt
+++ b/tests/comparison_misc/003.phpt
@@ -16,11 +16,10 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$[(@.length-1)]");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
+Fatal error: Uncaught RuntimeException: Unexpected filter element in %s
 Stack trace:
 %s
 %s


### PR DESCRIPTION
- Support filters inside expressions. Fixes 2 tests.
- Fix negative index bug caused by overwritten AST node index value. Fixes 1 test. 