### PR TITLE
Fix memory leak in filter list parsing

### DIFF
--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -210,6 +210,7 @@ static struct ast_node* parse_filter(PARSER_PARAMS) {
     case LEX_SLICE:
       expr = ast_alloc_node(NULL, AST_INDEX_LIST);
       if (!parse_filter_list(PARSER_ARGS, expr)) {
+        free_ast_nodes(expr);
         return NULL;
       }
       break;


### PR DESCRIPTION
With PHP in debug mode, I got two tests failing with a memory leak.

- tests/comparison_union/012.phpt
- tests/comparison_union/013.phpt