### PR TITLE
Throw exception on root in dot selector node name

### DIFF
--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -571,6 +571,13 @@ bool validate_parse_tree(struct ast_node* head) {
           return false;
         }
         break;
+      case AST_SELECTOR:
+        /* Expressions like $.$ and $.node$ are not allowed. Bracket notation $['$'] and $['node$'] should be used instead. */
+        if (cur->next != NULL && cur->next->type == AST_ROOT) {
+          zend_throw_exception(spl_ce_RuntimeException,
+                             "Unexpected root `$` in node name, use bracket notation for node names with special characters", 0);
+          return false;
+        }
       default:
         break;
     }

--- a/tests/comparison_dot_notation/030.phpt
+++ b/tests/comparison_dot_notation/030.phpt
@@ -15,11 +15,9 @@ $result = $jsonPath->find($data, "$.$");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-Assertion 1
-array(1) {
-  [0]=>
-  string(5) "value"
-}
---XFAIL--
-Requires support for a wider range of characters in node names
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unexpected root `$` in node name, use bracket notation for node names with special characters in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
I changed the expected outcome of `tests/comparison_dot_notation/030.phpt` (test dot notation with key root literal, `$.$`) from returning the value to throwing an exception. It feels clearer IMHO, and this is one of those comparison tests that very much lack a consensus behavior.

So if the node name consists of letters, digits, dashes and underscores, one can use the dot selector. Any other characters => use the bracket notation.

Closes https://github.com/supermetrics-public/php-ext-jsonpath/issues/55.