### PR TITLE
Refactor operators into recursive descent parser

### DIFF
--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -130,6 +130,10 @@ void exec_index_filter(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval
 }
 
 void exec_slice(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
+  if (arr_cur == NULL || Z_TYPE_P(arr_cur) != IS_ARRAY) {
+    return;
+  }
+
   zval* data;
   int i;
 

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -86,13 +86,10 @@ struct ast_node {
   union ast_node_data data;
 };
 
-bool build_parse_tree(struct jpath_token lex_tok[PARSE_BUF_LEN], int* lex_idx, int lex_tok_count,
-                      struct ast_node* head);
-bool sanity_check(struct jpath_token lex_token[], int lex_tok_count);
 void free_ast_nodes(struct ast_node* head);
 bool is_binary(enum ast_type type);
 bool is_unary(enum ast_type type);
-bool validate_parse_tree(struct ast_node* head);
+struct ast_node* parse_jsonpath(struct jpath_token lex_tok[PARSE_BUF_LEN], int* lex_idx, int lex_tok_count);
 
 #ifdef JSONPATH_DEBUG
 void print_ast(struct ast_node* head, const char* m, int level);

--- a/tests/comparison_dot_notation/049.phpt
+++ b/tests/comparison_dot_notation/049.phpt
@@ -16,7 +16,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: JSONPath expression must start with a root `$` in %s
+Fatal error: Uncaught RuntimeException: JSONPath must start with a root operator `$` in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/035.phpt
+++ b/tests/comparison_filter/035.phpt
@@ -46,5 +46,3 @@ array(2) {
     int(1)
   }
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_misc/001.phpt
+++ b/tests/comparison_misc/001.phpt
@@ -17,7 +17,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: JSONPath expression contains no valid elements in %s
+Fatal error: Uncaught RuntimeException: JSONPath must start with a root operator `$` in %s
 Stack trace:
 %s
 %s


### PR DESCRIPTION
I realized that implementing support for unions, array syntax and sets would be easier if I folded the rest of the parsing logic into the recursive descent parser pattern. This PR is a first pass at that effort. 

Some highlights:
- A net reduction in code
- Removed `sanity_check()`, `validate_parse_tree()`, `validate_root_next()`, which were kind of a band-aid for error handling. All the error checks are now done within the recursive descent parser.
- Removed dummy head node (not a big deal, but it bugged me)

I'm hoping to remove some of the redundant logic in `parse_primary()` in the next pass.