### PR TITLE
Fix various edge cases in error handling, with some added tests

### DIFF
--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -1,6 +1,9 @@
 #include "interpreter.h"
 
 #include <ext/pcre/php_pcre.h>
+#include <ext/spl/spl_exceptions.h>
+
+#include "zend_exceptions.h"
 
 #include "lexer.h"
 
@@ -237,6 +240,7 @@ bool compare_rgxp(zval* lh, zval* rh) {
   pcre_cache_entry* pce;
 
   if ((pce = pcre_get_compiled_regex_cache(Z_STR_P(rh))) == NULL) {
+    zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Invalid regex pattern `%s`", Z_STRVAL_P(rh));
     zval_ptr_dtor(rh);
     return false;
   }

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -334,6 +334,12 @@ static struct ast_node* parse_equality(PARSER_PARAMS) {
 
     struct ast_node* right = parse_comparison(PARSER_ARGS);
 
+    if (right == NULL) {
+      free_ast_nodes(expr);
+      free_ast_nodes(right);
+      return NULL;
+    }
+
     expr = ast_alloc_binary(type, expr, right);
   }
 
@@ -363,6 +369,12 @@ static struct ast_node* parse_comparison(PARSER_PARAMS) {
     CONSUME_TOKEN();
 
     struct ast_node* right = parse_unary(PARSER_ARGS);
+
+    if (right == NULL) {
+      free_ast_nodes(expr);
+      free_ast_nodes(right);
+      return NULL;
+    }
 
     expr = ast_alloc_binary(type, expr, right);
   }
@@ -395,6 +407,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
   if (CUR_TOKEN() == LEX_LITERAL_NUMERIC) {
     struct ast_node* ret = ast_alloc_node(NULL, AST_DOUBLE);
     if (!make_numeric_node(ret, CUR_TOKEN_LITERAL(), CUR_TOKEN_LEN())) {
+      free_ast_nodes(ret);
       zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unable to parse numeric");
       return NULL;
     }
@@ -410,6 +423,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
     } else if (strncasecmp("false", CUR_TOKEN_LITERAL(), 5) == 0) {
       ret->data.d_literal.value_bool = false;
     } else {
+      free_ast_nodes(ret);
       zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Expected `true` or `false` for boolean token");
       return NULL;
     }

--- a/tests/015.phpt
+++ b/tests/015.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test array slice with strings as start, end, and step
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$jsonPath = new JsonPath();
+
+$data = [
+  'words' => [
+    'soggy',
+    'minor',
+    'elated',
+    'unnatural',
+    'grubby',
+    'fabulous',
+    'parsimonious',
+    'cheerful',
+    'unadvised',
+    'simplistic',
+  ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.words['first':'last':'two']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Missing closing bracket `]` at position 15 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/016.phpt
+++ b/tests/016.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test array slice with unquoted strings as start, end, and step
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$jsonPath = new JsonPath();
+
+$data = [
+  'words' => [
+    'soggy',
+    'minor',
+    'elated',
+    'unnatural',
+    'grubby',
+    'fabulous',
+    'parsimonious',
+    'cheerful',
+    'unadvised',
+    'simplistic',
+  ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.words[first:last:two]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unrecognized token `l` at position 14 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/017.phpt
+++ b/tests/017.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test array slice with mix of unquoted string and numbers as start, end, and step
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$jsonPath = new JsonPath();
+
+$data = [
+  'words' => [
+    'soggy',
+    'minor',
+    'elated',
+    'unnatural',
+    'grubby',
+    'fabulous',
+    'parsimonious',
+    'cheerful',
+    'unadvised',
+    'simplistic',
+  ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.words[first:-1:2]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unexpected filter element in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/018.phpt
+++ b/tests/018.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test array slice with wildcard as end
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$jsonPath = new JsonPath();
+
+$data = [
+  'words' => [
+    'soggy',
+    'minor',
+    'elated',
+    'unnatural',
+    'grubby',
+    'fabulous',
+    'parsimonious',
+    'cheerful',
+    'unadvised',
+    'simplistic',
+  ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.words[0:*:2]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unexpected token `LEX_WILD_CARD` in filter in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/019.phpt
+++ b/tests/019.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Test broken boolean as right-hand operand
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$jsonPath = new JsonPath();
+
+$data = [
+  'words' => [
+     [
+      'isAdjective' => true,
+      'value'       => 'soggy',
+    ],
+    [
+      'isAdjective' => true,
+      'value'       => 'minor',
+    ],
+    [
+      'isAdjective' => true,
+      'value'       => 'elated',
+    ],
+    [
+      'isAdjective' => true,
+      'value'       => 'unnatural',
+    ],
+    [
+      'isAdjective' => true,
+      'value'       => 'grubby',
+    ],
+  ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.words[?(@.isAdjective == truse)]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Expected `true` or `false` for boolean token in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/020.phpt
+++ b/tests/020.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Test broken boolean as left-hand operand
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$jsonPath = new JsonPath();
+
+$data = [
+  'words' => [
+     [
+      'isAdjective' => true,
+      'value'       => 'soggy',
+    ],
+    [
+      'isAdjective' => true,
+      'value'       => 'minor',
+    ],
+    [
+      'isAdjective' => true,
+      'value'       => 'elated',
+    ],
+    [
+      'isAdjective' => true,
+      'value'       => 'unnatural',
+    ],
+    [
+      'isAdjective' => true,
+      'value'       => 'grubby',
+    ],
+  ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.words[?(falsue == @.isAdjective)]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Expected `true` or `false` for boolean token in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/021.phpt
+++ b/tests/021.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Test dot selector with misplaced current node operator
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$jsonPath = new JsonPath();
+
+$data = [
+  'words' => [
+     [
+      'type'  => 'adjective',
+      'value' => 'soggy',
+    ],
+    [
+      'type'  => 'adjective',
+      'value' => 'minor',
+    ],
+    [
+      'type'  => 'adjective',
+      'value' => 'elated',
+    ],
+    [
+      'type'  => 'adjective',
+      'value' => 'unnatural',
+    ],
+    [
+      'type'  => 'adjective',
+      'value' => 'grubby',
+    ],
+  ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.words.@");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Expecting child node, filter, expression, or recursive node in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/overflow/003.phpt
+++ b/tests/overflow/003.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test array slice with overflowing values for start, end, and stop
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$jsonPath = new JsonPath();
+
+$data = [
+  'words' => [
+    'soggy',
+    'minor',
+    'elated',
+    'unnatural',
+    'grubby',
+    'fabulous',
+    'parsimonious',
+    'cheerful',
+    'unadvised',
+    'simplistic',
+  ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.words[9223372036854775808:9223372036854775809:9223372036854775810]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unable to parse filter index value in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/overflow/004.phpt
+++ b/tests/overflow/004.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test bracket notation with overflowing index
+Test filter with overflowing operand
 --SKIPIF--
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
 --FILE--

--- a/tests/overflow/004.phpt
+++ b/tests/overflow/004.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Test bracket notation with overflowing index
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$jsonPath = new JsonPath();
+
+$data = [
+  'words' => [
+     [
+      'occurrences' => 647812,
+      'value'       => 'soggy',
+    ],
+    [
+      'occurrences' => 214216781,
+      'value'       => 'minor',
+    ],
+    [
+      'occurrences' => 1426,
+      'value'       => 'elated',
+    ],
+    [
+      'occurrences' => 126781,
+      'value'       => 'unnatural',
+    ],
+    [
+      'occurrences' => 972840012,
+      'value'       => 'grubby',
+    ],
+  ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.words[?($.occurrences > 9223372036854775808)]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unable to parse numeric in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/regex/001.phpt
+++ b/tests/regex/001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Testing <= operator
+Test regex with a match
 --SKIPIF--
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
 --FILE--

--- a/tests/regex/002.phpt
+++ b/tests/regex/002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Testing <= operator
+Test regex without a match
 --SKIPIF--
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
 --FILE--

--- a/tests/regex/003.phpt
+++ b/tests/regex/003.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test regex with broken regex pattern
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+  'test' => [
+      [
+        'id'      => 1,
+        'val'     => 10,
+        'val_str' => 'PHP is the web scripting language of choice',
+      ],
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$.test[?(@.val_str =~ "/invalid([a-]+/")]');
+
+echo "Assertion 1\n";
+var_dump($result);
+--EXPECTF--
+Warning: JsonPath::find(): Compilation failed: missing closing parenthesis at offset 13 in %s
+
+Fatal error: Uncaught RuntimeException: Invalid regex pattern `/invalid([a-]+/` in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
Some more tests and additional error handling here and there.

- Array slice with strings as start, end, and step
- Array slice with unquoted strings as start, end, and step
- Array slice with mix of unquoted string and numbers as start, end, and step
- Array slice with wildcard as end
- Broken boolean (`truse`) as right-hand operand
- Broken boolean (`falsue`) as left-hand operand
- Dot selector with misplaced current node operator
- Array slice with overflowing values for start, end, and stop
- Filter with overflowing operand
- Regex with broken regex pattern

Most of these came from analyzing the code coverage.