### PR TITLE
Make parse_primary loop back into recursive descent parser

### DIFF
--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -3,9 +3,8 @@
 #include <ext/pcre/php_pcre.h>
 #include <ext/spl/spl_exceptions.h>
 
-#include "zend_exceptions.h"
-
 #include "lexer.h"
+#include "zend_exceptions.h"
 
 int compare(zval* lh, zval* rh);
 bool compare_rgxp(zval* lh, zval* rh);
@@ -442,7 +441,6 @@ bool evaluate_binary(zval* arr_head, zval* arr_cur, struct ast_node* tok) {
     zval_ptr_dtor(val_rh);
   }
 
-FREE_LHS:
   if (lh_operand->type == AST_LITERAL) {
     zval_ptr_dtor(val_lh);
   }

--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -78,7 +78,9 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
           case '[':
             break; /* dot is superfluous in .['node'] */
           case '*':
-            break; /* get in next loop */
+            token->type = LEX_WILD_CARD;
+            NEXT_CHAR();
+            return true;
           case ' ':
             raise_error("Unexpected whitespace", json_path, *p);
             return false;
@@ -120,6 +122,15 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
             break;
           case '?':
             token->type = LEX_EXPR_START;
+            NEXT_CHAR();
+            return true;
+          case '*':
+            token->type = LEX_WILD_CARD;
+            NEXT_CHAR();
+            if (CUR_CHAR() != ']') {
+              raise_error("Wildcard filter contains an invalid character, expected `]`", json_path, *p);
+              return false;
+            }
             NEXT_CHAR();
             return true;
           default:
@@ -220,10 +231,6 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
           return false;
         }
         token->type = LEX_LITERAL;
-        return true;
-      case '*':
-        token->type = LEX_WILD_CARD;
-        NEXT_CHAR();
         return true;
       case 't':
       case 'T':

--- a/tests/018.phpt
+++ b/tests/018.phpt
@@ -29,7 +29,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unexpected token `LEX_WILD_CARD` in filter in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `*` at position 10 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/022.phpt
+++ b/tests/comparison_filter/022.phpt
@@ -21,7 +21,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Filter expressions may not be empty in %s
+Fatal error: Uncaught RuntimeException: Expecting child node, filter, expression, or recursive node in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/053.phpt
+++ b/tests/comparison_filter/053.phpt
@@ -26,11 +26,10 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$[?(@.key*2==100)]");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Multiplying node values is not supported in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `*` at position 9 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_union/015.phpt
+++ b/tests/comparison_union/015.phpt
@@ -16,11 +16,10 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$[*,1]");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
+Fatal error: Uncaught RuntimeException: Wildcard filter contains an invalid character, expected `]` at position 3 in %s
 Stack trace:
 %s
 %s


### PR DESCRIPTION
Remove redundant logic in `parse_primary()`.

This change made detecting the `Multiplying node values is not supported` check impractical because it's difficult to keep track of whether a node selector followed by a wildcard falls within an expression. 

After thinking it over, I realized that `$[?(@.key*2==100)]` is arguably a lexing error rather than a parsing error. The only allowed wildcard syntax includes the following: `.*`, `..*` and `[*]`. Based on that, `@.key*2` is invalid. I moved this check into the lexer, where it returns `Unrecognized token...`. 

I think this is a bit cleaner than explicitly forbidding multiplication (why not subtraction, etc...). Let me know what you think.
 