### PR TITLE
Support union filter

### DIFF
--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -106,20 +106,6 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
         EAT_WHITESPACE();
 
         switch (CUR_CHAR()) {
-          case '\'':
-          case '"':
-            if (!extract_quoted_literal(p, json_path, token)) {
-              return false;
-            }
-
-            EAT_WHITESPACE();
-
-            if (CUR_CHAR() != ']') {
-              raise_error("Missing closing bracket `]`", json_path, *p);
-              return false;
-            }
-            token->type = LEX_NODE;
-            break;
           case '?':
             token->type = LEX_EXPR_START;
             NEXT_CHAR();

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -32,6 +32,7 @@ enum ast_type {
   AST_LTE,
   AST_NE,
   AST_NEGATION,
+  AST_NODE_LIST,
   AST_NULL,
   AST_OR,
   AST_PAREN_LEFT,
@@ -57,6 +58,11 @@ union ast_node_data {
     int count;
     int indexes[10]; /* todo check for max */
   } d_list;
+  struct {
+    int count;
+    int len[10];   /* todo check for max */
+    char* str[10]; /* todo check for max */
+  } d_nodes;
   struct {
     char* val;
     int len;

--- a/tests/015.phpt
+++ b/tests/015.phpt
@@ -29,7 +29,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing bracket `]` at position 15 in %s
+Fatal error: Uncaught RuntimeException: Array slice indexes must be integers in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_bracket_notation/030.phpt
+++ b/tests/comparison_bracket_notation/030.phpt
@@ -16,7 +16,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing bracket `]` at position %d in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token `q` at position 10 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_bracket_notation/036.phpt
+++ b/tests/comparison_bracket_notation/036.phpt
@@ -24,7 +24,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing bracket `]` at position 7 in %s
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 8 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/020.phpt
+++ b/tests/comparison_dot_notation/020.phpt
@@ -21,16 +21,12 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$['one','three'].key");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-Assertion 1
 array(2) {
   [0]=>
   string(5) "value"
   [1]=>
   string(11) "other value"
 }
---XFAIL--
-Requires support for union with string literal keys

--- a/tests/comparison_union/003.phpt
+++ b/tests/comparison_union/003.phpt
@@ -12,16 +12,12 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$['a','a']");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-Assertion 1
 array(2) {
   [0]=>
   int(1)
   [1]=>
   int(1)
 }
---XFAIL--
-Requires more work on union implementation

--- a/tests/comparison_union/005.phpt
+++ b/tests/comparison_union/005.phpt
@@ -13,16 +13,12 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$['key','another']");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-Assertion 1
 array(2) {
   [0]=>
   string(5) "value"
   [1]=>
   string(5) "entry"
 }
---XFAIL--
-Requires more work on union implementation

--- a/tests/comparison_union/006.phpt
+++ b/tests/comparison_union/006.phpt
@@ -13,14 +13,10 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$['missing','key']");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-Assertion 1
 array(1) {
   [0]=>
   string(5) "value"
 }
---XFAIL--
-Requires more work on union implementation

--- a/tests/comparison_union/007.phpt
+++ b/tests/comparison_union/007.phpt
@@ -21,11 +21,9 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$[:]['c','d']");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-Assertion 1
 array(4) {
   [0]=>
   string(3) "cc1"
@@ -36,5 +34,3 @@ array(4) {
   [3]=>
   string(3) "dd2"
 }
---XFAIL--
-Requires more work on union implementation

--- a/tests/comparison_union/008.phpt
+++ b/tests/comparison_union/008.phpt
@@ -21,16 +21,12 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$[0]['c','d']");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-Assertion 1
 array(2) {
   [0]=>
   string(3) "cc1"
   [1]=>
   string(3) "dd1"
 }
---XFAIL--
-Requires more work on union implementation

--- a/tests/comparison_union/009.phpt
+++ b/tests/comparison_union/009.phpt
@@ -21,11 +21,9 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$.*['c','d']");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-Assertion 1
 array(4) {
   [0]=>
   string(3) "cc1"
@@ -36,5 +34,3 @@ array(4) {
   [3]=>
   string(3) "dd2"
 }
---XFAIL--
-Requires more work on union implementation

--- a/tests/comparison_union/010.phpt
+++ b/tests/comparison_union/010.phpt
@@ -35,11 +35,9 @@ $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$..['c','d']");
 sortRecursively($result);
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-Assertion 1
 array(7) {
   [0]=>
   string(3) "cc1"
@@ -56,5 +54,3 @@ array(7) {
   [6]=>
   string(3) "dd4"
 }
---XFAIL--
-Requires more work on union implementation

--- a/tests/lex_errs/001.phpt
+++ b/tests/lex_errs/001.phpt
@@ -9,7 +9,7 @@ $jsonPath = new JsonPath();
 
 $jsonPath->find([], "$.testl['test'");
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing bracket `]` at position 14 in %s
+Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
 Stack trace:
 %s
 %s

--- a/tests/lex_errs/002.phpt
+++ b/tests/lex_errs/002.phpt
@@ -9,7 +9,7 @@ $jsonPath = new JsonPath();
 
 $jsonPath->find([], '$.testl["test"');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing bracket `]` at position 14 in %s
+Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
 Stack trace:
 %s
 %s


### PR DESCRIPTION
Implement support for union filter. Fixes 8 tests, improves error messages for others.

I will add bounds checking for the `len` and `string` members in the next PR.