### PR TITLE
Expect exception in union with filter test

### DIFF
--- a/tests/comparison_union/004.phpt
+++ b/tests/comparison_union/004.phpt
@@ -38,34 +38,9 @@ $result = $jsonPath->find($data, "$[?(@.key<3),?(@.key>6)]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-Assertion 1
-array(5) {
-  [0]=>
-  array(1) {
-    ["key"]=>
-    int(1)
-  }
-  [1]=>
-  array(1) {
-    ["key"]=>
-    int(2)
-  }
-  [2]=>
-  array(1) {
-    ["key"]=>
-    int(8)
-  }
-  [3]=>
-  array(1) {
-    ["key"]=>
-    int(10)
-  }
-  [4]=>
-  array(1) {
-    ["key"]=>
-    int(7)
-  }
-}
---XFAIL--
-Requires more work on union implementation
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unrecognized token `?` at position 13 in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
As discussed in #52, we can choose not to support expressions with unions of filters.

Closes #52.