### PR TITLE
Support unquoted regex patterns

### DIFF
--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -20,6 +20,7 @@ static bool extract_quoted_literal(char** p, char* json_path, struct jpath_token
 static void extract_unbounded_literal(char** p, char* json_path, struct jpath_token* token);
 static void extract_unbounded_numeric_literal(char** p, char* json_path, struct jpath_token* token);
 static void extract_boolean_or_null_literal(char** p, char* json_path, struct jpath_token* token);
+static bool extract_regex(char** p, char* json_path, struct jpath_token* token);
 
 const char* LEX_STR[] = {
     "LEX_NOT_FOUND",       /* Token not found */
@@ -230,6 +231,12 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
         extract_boolean_or_null_literal(p, json_path, token);
         token->type = LEX_LITERAL_NULL;
         return true;
+      case '/':
+        if (!extract_regex(p, json_path, token)) {
+          return false;
+        }
+        token->type = LEX_LITERAL;
+        return true;
       case '-':
       case '0':
       case '1':
@@ -300,6 +307,36 @@ static bool extract_quoted_literal(char** p, char* json_path, struct jpath_token
     NEXT_CHAR();
   }
 
+  NEXT_CHAR();
+
+  return true;
+}
+
+static bool extract_regex(char** p, char* json_path, struct jpath_token* token) {
+  token->len = 0;
+  token->val = *p;
+  char* start = *p;
+
+  /* consume opening slash */
+  token->len++;
+  NEXT_CHAR();
+
+  for (; CUR_CHAR() != '\0' && CUR_CHAR() != '/'; NEXT_CHAR()) {
+    if (CUR_CHAR() == '\\' && PEEK_CHAR() == '/') {
+      /* skip escaped forward slash */
+      token->len++;
+      NEXT_CHAR();
+    }
+    token->len++;
+  }
+
+  if (CUR_CHAR() != '/') {
+    raise_error("Missing closing regex /", json_path, start);
+    return false;
+  }
+
+  /* consume closing slash */
+  token->len++;
   NEXT_CHAR();
 
   return true;

--- a/tests/comparison_filter/019.phpt
+++ b/tests/comparison_filter/019.phpt
@@ -30,7 +30,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `/` at position 9 in %s
+Fatal error: Uncaught RuntimeException: Missing closing regex / at position 9 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/057.phpt
+++ b/tests/comparison_filter/057.phpt
@@ -26,7 +26,6 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$[?(@.name=~/hello.*/)]");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
@@ -39,8 +38,6 @@ array(2) {
   [1]=>
   array(1) {
     ["name"]=>
-    string(14) "yes hello world"
+    string(15) "yes hello world"
   }
 }
---XFAIL--
-Regexps currently need to be wrapped in quotes

--- a/tests/comparison_filter/058.phpt
+++ b/tests/comparison_filter/058.phpt
@@ -2,6 +2,8 @@
 Test filter expression with regular expression from member
 --SKIPIF--
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--DESCRIPTION--
+JSONPath node selectors are not interpolated within regex patterns.
 --FILE--
 <?php
 
@@ -29,12 +31,7 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$[?(@.name=~/@.pattern/)]");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `/` at position 12 in %s
-Stack trace:
-%s
-%s
-%s
+--EXPECT--
+bool(false)


### PR DESCRIPTION
Implement support for unquoted regex patterns, including patterns with escaped forward slashes.

I propose here that we do not support interpolating patterns, such as`/@.pattern/`. This doesn't seem like a widely supported feature and it would unnecessarily increase lexer complexity. LMK what you think.
