### PR TITLE
Fix memory leak when expression ends with a lonely recursive descent operator

### DIFF
--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -86,12 +86,13 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
             raise_error("Unexpected whitespace", json_path, *p);
             return false;
           case '\0':
-            /* The whole expression can end with a recursive descent operator, but not with a dot selector */
-            if (*(*p - 2) != '.') {
-              raise_error("Dot selector `.` must be followed by a node name or wildcard", json_path, *p - 1);
+            if (*(*p - 2) == '.') {
+              raise_error("Recursive descent operator `..` must be followed by a child selector, filter or wildcard", json_path, *p);
               return false;
             }
-            return true;
+
+            raise_error("Dot selector `.` must be followed by a node name or wildcard", json_path, *p - 1);
+            return false;
           default:
             if (CUR_CHAR() == '"' || CUR_CHAR() == '\'') {
               raise_error("Quoted node names must use the bracket notation `[`", json_path, *p);

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -185,13 +185,6 @@ static struct ast_node* parse_operator(PARSER_PARAMS) {
     case LEX_DEEP_SCAN:
       expr = ast_alloc_node(NULL, AST_RECURSE);
       CONSUME_TOKEN();
-      /* todo : why is LEX_NOT_FOUND generated in tests/comparison_recursive_descent/002.php? */
-      if (!HAS_TOKEN() || (CUR_TOKEN() == LEX_NODE && CUR_TOKEN_LEN() == 0) || CUR_TOKEN() == LEX_NOT_FOUND) {
-        zend_throw_exception(spl_ce_RuntimeException,
-                             "Recursive descent operator `..` must be followed by a child selector, filter or wildcard",
-                             0);
-        return NULL;
-      }
       break;
     case LEX_WILD_CARD:
       expr = ast_alloc_node(NULL, AST_WILD_CARD);

--- a/tests/comparison_recursive_descent/001.phpt
+++ b/tests/comparison_recursive_descent/001.phpt
@@ -24,7 +24,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard in %s
+Fatal error: Uncaught RuntimeException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_recursive_descent/002.phpt
+++ b/tests/comparison_recursive_descent/002.phpt
@@ -23,7 +23,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard in %s
+Fatal error: Uncaught RuntimeException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard at position 7 in %s
 Stack trace:
 %s
 %s


### PR DESCRIPTION
I moved the "Recursive descent operator `..` must be followed by a child selector, filter or wildcard" error to the lexer. I can't remember why I previously thought that the expression can end with a recursive descent operator, but it probably shouldn't.