### PR TITLE
Configure PR autolabeler for release drafting

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,6 +25,21 @@ version-resolver:
     labels:
       - 'patch'
   default: patch
+autolabeler:
+  - label: 'chore'
+    files:
+      - '*.md'
+    branch:
+      - '/chore\/.+/'
+      - '/docs{0,1}\/.+/'
+  - label: 'bugfix'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'feature'
+    branch:
+      - '/feature\/.+/'
 template: |
   ## Changes
 


### PR DESCRIPTION
This should give the PRs labels automatically based on branch names, PR titles, or the types of files changed. The labels are then used in the release draft.