### PR TITLE
Disable PCRE jit to avoid alleged valgrind errors.

### DIFF
--- a/tests/023.phpt
+++ b/tests/023.phpt
@@ -2,6 +2,8 @@
 Test filter expression with regular expression that contains escaped slash
 --SKIPIF--
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--INI--
+pcre.jit=0
 --FILE--
 <?php
 

--- a/tests/comparison_filter/057.phpt
+++ b/tests/comparison_filter/057.phpt
@@ -2,6 +2,8 @@
 Test filter expression with regular expression
 --SKIPIF--
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--INI--
+pcre.jit=0
 --FILE--
 <?php
 

--- a/tests/comparison_filter/058.phpt
+++ b/tests/comparison_filter/058.phpt
@@ -4,6 +4,8 @@ Test filter expression with regular expression from member
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
 --DESCRIPTION--
 JSONPath node selectors are not interpolated within regex patterns.
+--INI--
+pcre.jit=0
 --FILE--
 <?php
 

--- a/tests/regex/002.phpt
+++ b/tests/regex/002.phpt
@@ -2,6 +2,8 @@
 Test regex without a match
 --SKIPIF--
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--INI--
+pcre.jit=0
 --FILE--
 <?php
 


### PR DESCRIPTION

So........there is a reasonable chance the alleged read from uninitialized memory is a false report: https://bugs.php.net/bug.php?id=81240 . In particular, as compiling with valgrind support makes the report dissapear it's more likely to be a false report than not.

Disabling the pcre.jit option also makes the issue go away. As you should be occcasionally testing to check for leaks, having the false reports not be there would be better than having people be confused by them.

There's a small chance the error alleged by valgrind is legitimate, and that it should be isolated and reported upstream. But I only have energy for this PR.