### PR TITLE
Throw a custom JsonPathException instead of generic RuntimeException

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -14,6 +14,7 @@ PHP_ARG_ENABLE([code-coverage],
   [no])
 
 JSONPATH_SOURCES="\
+    src/jsonpath/exceptions.c \
     src/jsonpath/lexer.c \
     src/jsonpath/parser.c \
     src/jsonpath/interpreter.c \

--- a/jsonpath.c
+++ b/jsonpath.c
@@ -7,6 +7,7 @@
 #include "ext/standard/info.h"
 #include "php.h"
 #include "php_jsonpath.h"
+#include "src/jsonpath/exceptions.h"
 #include "src/jsonpath/interpreter.h"
 #include "src/jsonpath/lexer.h"
 #include "src/jsonpath/parser.h"
@@ -18,6 +19,7 @@ void print_lex_tokens(struct jpath_token lex_tok[], int lex_tok_count, const cha
 #endif
 
 zend_class_entry* jsonpath_ce;
+zend_class_entry *jsonpath_exception_ce;
 
 #if PHP_VERSION_ID < 80000
 #include "jsonpath_legacy_arginfo.h"
@@ -96,8 +98,7 @@ static bool scan_tokens(char* json_path, struct jpath_token* tok, int* tok_count
 
   while (*p != '\0') {
     if (i >= LEX_TOK_ARR_LEN) {
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0,
-                              "The query is too long, token count exceeds maximum amount (%d)", LEX_TOK_ARR_LEN);
+      throw_jsonpath_exception("The query is too long, token count exceeds maximum amount (%d)", LEX_TOK_ARR_LEN);
       return false;
     }
 
@@ -131,10 +132,9 @@ void print_lex_tokens(struct jpath_token lex_tok[], int lex_tok_count, const cha
 /* {{{ PHP_MINIT_FUNCTION
  */
 PHP_MINIT_FUNCTION(jsonpath) {
-  zend_class_entry jsonpath_class_entry;
-  INIT_NS_CLASS_ENTRY(jsonpath_class_entry, "JsonPath", "JsonPath", class_JsonPath_JsonPath_methods);
+  jsonpath_ce = register_class_JsonPath_JsonPath();
 
-  jsonpath_ce = zend_register_internal_class(&jsonpath_class_entry);
+  jsonpath_exception_ce = register_class_JsonPath_JsonPathException(spl_ce_RuntimeException);
 
   return SUCCESS;
 }

--- a/jsonpath.c
+++ b/jsonpath.c
@@ -19,7 +19,7 @@ void print_lex_tokens(struct jpath_token lex_tok[], int lex_tok_count, const cha
 #endif
 
 zend_class_entry* jsonpath_ce;
-zend_class_entry *jsonpath_exception_ce;
+zend_class_entry* jsonpath_exception_ce;
 
 #if PHP_VERSION_ID < 80000
 #include "jsonpath_legacy_arginfo.h"

--- a/jsonpath.stub.php
+++ b/jsonpath.stub.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @generate-function-entries
+ * @generate-class-entries
  * @generate-legacy-arginfo
  */
 
@@ -14,6 +14,12 @@ class JsonPath
      * @param string $expression
      *
      * @return array|bool
+     *
+     * @throws JsonPathException
      */
     public function find(array $data, string $expression): array|bool;
+}
+
+class JsonPathException extends \RuntimeException
+{
 }

--- a/jsonpath_arginfo.h
+++ b/jsonpath_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 115d6bb613c65d1d0624a02b37544ad3f8ea697d */
+ * Stub hash: 27fbe76d157af97672d8d6e085e2c68684e1024b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_JsonPath_JsonPath_find, 0, 2, MAY_BE_ARRAY|MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
@@ -14,3 +14,28 @@ static const zend_function_entry class_JsonPath_JsonPath_methods[] = {
 	ZEND_ME(JsonPath_JsonPath, find, arginfo_class_JsonPath_JsonPath_find, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
+
+
+static const zend_function_entry class_JsonPath_JsonPathException_methods[] = {
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_JsonPath_JsonPath(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "JsonPath", "JsonPath", class_JsonPath_JsonPath_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_JsonPath_JsonPathException(zend_class_entry *class_entry_RuntimeException)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "JsonPath", "JsonPathException", class_JsonPath_JsonPathException_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_RuntimeException);
+
+	return class_entry;
+}

--- a/jsonpath_legacy_arginfo.h
+++ b/jsonpath_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 115d6bb613c65d1d0624a02b37544ad3f8ea697d */
+ * Stub hash: 27fbe76d157af97672d8d6e085e2c68684e1024b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_JsonPath_JsonPath_find, 0, 0, 2)
 	ZEND_ARG_INFO(0, data)
@@ -14,3 +14,28 @@ static const zend_function_entry class_JsonPath_JsonPath_methods[] = {
 	ZEND_ME(JsonPath_JsonPath, find, arginfo_class_JsonPath_JsonPath_find, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
+
+
+static const zend_function_entry class_JsonPath_JsonPathException_methods[] = {
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_JsonPath_JsonPath(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "JsonPath", "JsonPath", class_JsonPath_JsonPath_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_JsonPath_JsonPathException(zend_class_entry *class_entry_RuntimeException)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "JsonPath", "JsonPathException", class_JsonPath_JsonPathException_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_RuntimeException);
+
+	return class_entry;
+}

--- a/php_jsonpath.h
+++ b/php_jsonpath.h
@@ -27,35 +27,34 @@ extern zend_module_entry jsonpath_module_entry;
 #define PHP_JSONPATH_VERSION "0.9.1"
 
 #ifdef PHP_WIN32
-#	define PHP_JSONPATH_API __declspec(dllexport)
+#define PHP_JSONPATH_API __declspec(dllexport)
 #elif defined(__GNUC__) && __GNUC__ >= 4
-#	define PHP_JSONPATH_API __attribute__ ((visibility("default")))
+#define PHP_JSONPATH_API __attribute__((visibility("default")))
 #else
-#	define PHP_JSONPATH_API
+#define PHP_JSONPATH_API
 #endif
 
-/* 
-  	Declare any global variables you may need between the BEGIN
-	and END macros here:     
+/*
+        Declare any global variables you may need between the BEGIN
+        and END macros here:
 
 ZEND_BEGIN_MODULE_GLOBALS(jsonpath)
-	long  global_value;
-	char *global_string;
+        long  global_value;
+        char *global_string;
 ZEND_END_MODULE_GLOBALS(jsonpath)
 */
 
-/* In every utility function you add that needs to use variables 
-   in php_jsonpath_globals, call TSRMLS_FETCH(); after declaring other 
+/* In every utility function you add that needs to use variables
+   in php_jsonpath_globals, call TSRMLS_FETCH(); after declaring other
    variables used by that function, or better yet, pass in TSRMLS_CC
    after the last function argument and declare your utility function
    with TSRMLS_DC after the last declared argument.  Always refer to
-   the globals in your function as JSONPATH_G(variable).  You are 
+   the globals in your function as JSONPATH_G(variable).  You are
    encouraged to rename these macros something shorter, see
    examples in any other php module directory.
 */
 
-#endif	/* PHP_JSONPATH_H */
-
+#endif /* PHP_JSONPATH_H */
 
 /*
  * Local variables:

--- a/src/jsonpath/exceptions.c
+++ b/src/jsonpath/exceptions.c
@@ -7,7 +7,7 @@
 
 extern zend_class_entry *jsonpath_exception_ce;
 
-void throw_jsonpath_exception(const char* msg, ...) {
+void throw_jsonpath_exception(const char *msg, ...) {
   va_list args;
   char *formatted_msg = NULL;
 

--- a/src/jsonpath/exceptions.c
+++ b/src/jsonpath/exceptions.c
@@ -1,0 +1,19 @@
+#include "exceptions.h"
+
+#include <stdarg.h>
+
+#include "ext/spl/spl_exceptions.h"
+#include "zend_exceptions.h"
+
+extern zend_class_entry *jsonpath_exception_ce;
+
+void throw_jsonpath_exception(const char* msg, ...) {
+  va_list args;
+  char *formatted_msg = NULL;
+
+  va_start(args, msg);
+  zend_vspprintf(&formatted_msg, 0, msg, args);
+  zend_throw_exception(jsonpath_exception_ce, formatted_msg, 0);
+  efree(formatted_msg);
+  va_end(args);
+}

--- a/src/jsonpath/exceptions.h
+++ b/src/jsonpath/exceptions.h
@@ -1,0 +1,6 @@
+#ifndef JSONPATH_EXCEPTIONS_H
+#define JSONPATH_EXCEPTIONS_H 1
+
+void throw_jsonpath_exception(const char* msg, ...);
+
+#endif /* JSONPATH_EXCEPTIONS_H */

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -1,9 +1,9 @@
 #include "interpreter.h"
 
 #include "ext/pcre/php_pcre.h"
-#include "ext/spl/spl_exceptions.h"
+
+#include "exceptions.h"
 #include "lexer.h"
-#include "zend_exceptions.h"
 
 #define BOOL_ERR -1
 #define RETURN_ERR_IF_NULL(val) \
@@ -269,7 +269,7 @@ static bool compare_rgxp(zval* lh, zval* rh) {
   pcre_cache_entry* pce;
 
   if ((pce = pcre_get_compiled_regex_cache(Z_STR_P(rh))) == NULL) {
-    zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Invalid regex pattern `%s`", Z_STRVAL_P(rh));
+    throw_jsonpath_exception("Invalid regex pattern `%s`", Z_STRVAL_P(rh));
     return false;
   }
 
@@ -327,7 +327,7 @@ static zval* evaluate_primary(struct ast_node* src, zval* tmp_dest, zval* arr_he
       ZVAL_ARR(tmp_dest, src->data.d_list.ht);
       return tmp_dest;
     default:
-      zend_throw_exception(spl_ce_RuntimeException, "Unsupported expression operand", 0);
+      throw_jsonpath_exception("Unsupported expression operand");
       return NULL;
   }
 }

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -1,8 +1,7 @@
 #include "interpreter.h"
 
-#include "ext/pcre/php_pcre.h"
-
 #include "exceptions.h"
+#include "ext/pcre/php_pcre.h"
 #include "lexer.h"
 
 #define BOOL_ERR -1

--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -5,8 +5,7 @@
 #include <ctype.h>
 #endif
 
-#include "ext/spl/spl_exceptions.h"
-#include "zend_exceptions.h"
+#include "exceptions.h"
 
 #define CUR_CHAR() **p
 #define NEXT_CHAR() (*p)++
@@ -245,8 +244,7 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
         NEXT_CHAR();
         break;
       default:
-        zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unrecognized token `%c` at position %ld", CUR_CHAR(),
-                                (*p - json_path));
+        throw_jsonpath_exception("Unrecognized token `%c` at position %ld", CUR_CHAR(), (*p - json_path));
         return false;
     }
   }
@@ -255,7 +253,7 @@ bool scan(char** p, struct jpath_token* token, char* json_path) {
 }
 
 static void raise_error(const char* msg, char* json_path, char* cur_pos) {
-  zend_throw_exception_ex(spl_ce_RuntimeException, 0, "%s at position %ld", msg, (cur_pos - json_path));
+  throw_jsonpath_exception("%s at position %ld", msg, (cur_pos - json_path));
 }
 
 /* Extract contents of string bounded by either single or double quotes */

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -2,9 +2,8 @@
 
 #include <limits.h>
 
-#include "php.h"
-
 #include "exceptions.h"
+#include "php.h"
 
 #define CUR_POS() *lex_idx
 #define CONSUME_TOKEN() (CUR_POS())++

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -2,8 +2,9 @@
 
 #include <limits.h>
 
-#include "ext/spl/spl_exceptions.h"
-#include "zend_exceptions.h"
+#include "php.h"
+
+#include "exceptions.h"
 
 #define CUR_POS() *lex_idx
 #define CONSUME_TOKEN() (CUR_POS())++
@@ -82,8 +83,7 @@ static struct ast_node* get_binary_node_from_pool(struct node_pool* pool, enum a
 
 static struct ast_node* get_node_from_pool(struct node_pool* pool, enum ast_type type) {
   if (pool->cur_index >= NODE_POOL_LEN) {
-    zend_throw_exception_ex(
-        spl_ce_RuntimeException, 0,
+    throw_jsonpath_exception(
         "Expression requires more parser node slots than are available (%d), try a shorter expression", NODE_POOL_LEN);
     return NULL;
   }
@@ -121,15 +121,13 @@ static bool parse_filter_list(PARSER_PARAMS, struct ast_node* tok) {
       break;
     } else if (CUR_TOKEN() == LEX_CHILD_SEP) {
       if (sep_found == AST_INDEX_SLICE) {
-        zend_throw_exception(spl_ce_RuntimeException,
-                             "Multiple filter list separators `,` and `:` found, only one type is allowed", 0);
+        throw_jsonpath_exception("Multiple filter list separators `,` and `:` found, only one type is allowed");
         return false;
       }
       tok->type = sep_found = AST_INDEX_LIST;
     } else if (CUR_TOKEN() == LEX_SLICE) {
       if (sep_found == AST_INDEX_LIST) {
-        zend_throw_exception(spl_ce_RuntimeException,
-                             "Multiple filter list separators `,` and `:` found, only one type is allowed", 0);
+        throw_jsonpath_exception("Multiple filter list separators `,` and `:` found, only one type is allowed");
         return false;
       }
 
@@ -147,19 +145,19 @@ static bool parse_filter_list(PARSER_PARAMS, struct ast_node* tok) {
       long idx = 0;
 
       if (!numeric_to_long(CUR_TOKEN_LITERAL(), CUR_TOKEN_LEN(), &idx)) {
-        zend_throw_exception(spl_ce_RuntimeException, "Unable to parse filter index value", 0);
+        throw_jsonpath_exception("Unable to parse filter index value");
         return false;
       }
       ht_append_long(tok->data.d_list.ht, idx);
     } else if (CUR_TOKEN() == LEX_LITERAL) {
       if (sep_found == AST_INDEX_SLICE) {
-        zend_throw_exception(spl_ce_RuntimeException, "Array slice indexes must be integers", 0);
+        throw_jsonpath_exception("Array slice indexes must be integers");
         return false;
       }
       tok->type = sep_found = AST_NODE_LIST;
       ht_append_string(tok->data.d_list.ht, CUR_TOKEN_LITERAL(), CUR_TOKEN_LEN());
     } else {
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unexpected token `%s` in filter", LEX_STR[CUR_TOKEN()]);
+      throw_jsonpath_exception("Unexpected token `%s` in filter", LEX_STR[CUR_TOKEN()]);
       return false;
     }
   }
@@ -168,7 +166,7 @@ static bool parse_filter_list(PARSER_PARAMS, struct ast_node* tok) {
 
 struct ast_node* parse_jsonpath(PARSER_PARAMS) {
   if (!HAS_TOKEN() || CUR_TOKEN() != LEX_ROOT) {
-    zend_throw_exception_ex(spl_ce_RuntimeException, 0, "JSONPath must start with a root operator `$`");
+    throw_jsonpath_exception("JSONPath must start with a root operator `$`");
     return NULL;
   }
 
@@ -229,13 +227,11 @@ static struct ast_node* parse_operator(PARSER_PARAMS) {
     case LEX_ROOT:
       /* Expressions like $.$ and $.node$ are not allowed. Bracket notation $['$'] and $['node$'] should be used
        * instead. */
-      zend_throw_exception(
-          spl_ce_RuntimeException,
-          "Unexpected root `$` in node name, use bracket notation for node names with special characters", 0);
+      throw_jsonpath_exception(
+          "Unexpected root `$` in node name, use bracket notation for node names with special characters");
       return NULL;
     default:
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0,
-                              "Expecting child node, filter, expression, or recursive node");
+      throw_jsonpath_exception("Expecting child node, filter, expression, or recursive node");
       return NULL;
   }
 
@@ -255,7 +251,7 @@ static struct ast_node* parse_expression(PARSER_PARAMS) {
   CONSUME_TOKEN(); /* LEX_EXPR_START */
 
   if (CUR_TOKEN() != LEX_PAREN_OPEN) {
-    zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing opening paren `(`");
+    throw_jsonpath_exception("Missing opening paren `(`");
     return NULL;
   }
 
@@ -274,7 +270,7 @@ static struct ast_node* parse_filter(PARSER_PARAMS) {
   CONSUME_TOKEN();
 
   if (!HAS_TOKEN()) {
-    zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing filter end `]`");
+    throw_jsonpath_exception("Missing filter end `]`");
     return NULL;
   }
 
@@ -296,17 +292,17 @@ static struct ast_node* parse_filter(PARSER_PARAMS) {
       RETURN_IF_NULL(expr);
       break;
     case LEX_EXPR_END:
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Filter must not be empty");
+      throw_jsonpath_exception("Filter must not be empty");
       return NULL;
     default:
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unexpected filter element");
+      throw_jsonpath_exception("Unexpected filter element");
       return NULL;
   }
 
   CONSUME_TOKEN();
 
   if (!HAS_TOKEN() || CUR_TOKEN() != LEX_EXPR_END) {
-    zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing filter end `]`");
+    throw_jsonpath_exception("Missing filter end `]`");
     return NULL;
   }
 
@@ -434,7 +430,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
     struct ast_node* ret = GET_NODE(AST_DOUBLE);
     RETURN_IF_NULL(ret);
     if (!make_numeric_node(ret, CUR_TOKEN_LITERAL(), CUR_TOKEN_LEN())) {
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unable to parse numeric");
+      throw_jsonpath_exception("Unable to parse numeric");
       return NULL;
     }
     CONSUME_TOKEN();
@@ -450,7 +446,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
     } else if (strncasecmp("false", CUR_TOKEN_LITERAL(), 5) == 0) {
       ret->data.d_literal.value_bool = false;
     } else {
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Expected `true` or `false` for boolean token");
+      throw_jsonpath_exception("Expected `true` or `false` for boolean token");
       return NULL;
     }
     CONSUME_TOKEN();
@@ -477,7 +473,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
       CONSUME_TOKEN();
       return expr;
     } else {
-      zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing closing paren `)`");
+      throw_jsonpath_exception("Missing closing paren `)`");
       return NULL;
     }
   }
@@ -551,7 +547,7 @@ static bool validate_expression_head(struct ast_node* tok) {
     return true;
   }
 
-  zend_throw_exception(spl_ce_RuntimeException, "Invalid expression.", 0);
+  throw_jsonpath_exception("Invalid expression.");
 
   return false;
 }

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -5,9 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "zend_types.h"
-
 #include "lexer.h"
+#include "zend_types.h"
 
 #define NODE_POOL_LEN 64
 

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -5,8 +5,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "lexer.h"
 #include "zend_types.h"
+
+#include "lexer.h"
 
 #define NODE_POOL_LEN 64
 

--- a/tests/015.phpt
+++ b/tests/015.phpt
@@ -28,7 +28,7 @@ $result = $jsonPath->find($data, "$.words['first':'last':'two']");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Array slice indexes must be integers in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Array slice indexes must be integers in %s
 Stack trace:
 %s
 %s

--- a/tests/016.phpt
+++ b/tests/016.phpt
@@ -28,7 +28,7 @@ $result = $jsonPath->find($data, "$.words[first:last:two]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `l` at position 14 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `l` at position 14 in %s
 Stack trace:
 %s
 %s

--- a/tests/017.phpt
+++ b/tests/017.phpt
@@ -28,7 +28,7 @@ $result = $jsonPath->find($data, "$.words[first:-1:2]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unexpected filter element in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unexpected filter element in %s
 Stack trace:
 %s
 %s

--- a/tests/018.phpt
+++ b/tests/018.phpt
@@ -28,7 +28,7 @@ $result = $jsonPath->find($data, "$.words[0:*:2]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `*` at position 10 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `*` at position 10 in %s
 Stack trace:
 %s
 %s

--- a/tests/019.phpt
+++ b/tests/019.phpt
@@ -38,7 +38,7 @@ $result = $jsonPath->find($data, "$.words[?(@.isAdjective == truse)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Expected `true` or `false` for boolean token in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Expected `true` or `false` for boolean token in %s
 Stack trace:
 %s
 %s

--- a/tests/020.phpt
+++ b/tests/020.phpt
@@ -38,7 +38,7 @@ $result = $jsonPath->find($data, "$.words[?(falsue == @.isAdjective)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Expected `true` or `false` for boolean token in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Expected `true` or `false` for boolean token in %s
 Stack trace:
 %s
 %s

--- a/tests/021.phpt
+++ b/tests/021.phpt
@@ -38,7 +38,7 @@ $result = $jsonPath->find($data, "$.words.@");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Expecting child node, filter, expression, or recursive node in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Expecting child node, filter, expression, or recursive node in %s
 Stack trace:
 %s
 %s

--- a/tests/022.phpt
+++ b/tests/022.phpt
@@ -67,7 +67,7 @@ $result = $jsonPath->find($data, '$[?(@.d==[100,200])]');
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unsupported expression operand in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unsupported expression operand in %s
 Stack trace:
 %s
 %s

--- a/tests/bounds_checks/002.phpt
+++ b/tests/bounds_checks/002.phpt
@@ -5,13 +5,16 @@ Ensure queries that contain more than LEX_TOK_ARR_LEN tokens safely fail
 --FILE--
 <?php
 
-$jsonPath = new \JsonPath\JsonPath();
+use JsonPath\JsonPath;
+use JsonPath\JsonPathException;
+
+$jsonPath = new JsonPath();
 
 try {
-    // This query contains 51 tokens (root selector $ plus 50 dot selectors), which exceeds LEX_TOK_ARR_LEN
+    // This query contains 66 tokens (root selector $ plus 65 dot selectors), which exceeds LEX_TOK_ARR_LEN
     var_dump($jsonPath->find([], '$.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.17.18.19.20.21.22.23.24.25.26.27.28.29.30.31.32.33.34.35.36.37.38.39.40.41.42.43.44.45.46.47.48.49.50.51.52.53.54.55.56.57.58.59.60.61.62.63.64.65'));
-} catch(RuntimeException $e) {
+} catch (JsonPathException $e) {
     echo get_class($e) . ": " . $e->getMessage();
 }
 --EXPECT--
-RuntimeException: The query is too long, token count exceeds maximum amount (64)
+JsonPath\JsonPathException: The query is too long, token count exceeds maximum amount (64)

--- a/tests/bounds_checks/003.phpt
+++ b/tests/bounds_checks/003.phpt
@@ -28,7 +28,7 @@ $result = $jsonPath->find($data, "$.words[9223372036854775808:922337203685477580
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unable to parse filter index value in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unable to parse filter index value in %s
 Stack trace:
 %s
 %s

--- a/tests/bounds_checks/004.phpt
+++ b/tests/bounds_checks/004.phpt
@@ -38,7 +38,7 @@ $result = $jsonPath->find($data, "$.words[?($.occurrences > 9223372036854775808)
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unable to parse numeric in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unable to parse numeric in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_bracket_notation/007.phpt
+++ b/tests/comparison_bracket_notation/007.phpt
@@ -17,7 +17,7 @@ $result = $jsonPath->find($data, '$[]');
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Filter must not be empty in %s007.php:%d
+Fatal error: Uncaught JsonPath\JsonPathException: Filter must not be empty in %s007.php:%d
 Stack trace:
 %s
 %s

--- a/tests/comparison_bracket_notation/030.phpt
+++ b/tests/comparison_bracket_notation/030.phpt
@@ -15,7 +15,7 @@ $result = $jsonPath->find($data, "$['single'quote']");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `q` at position 10 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `q` at position 10 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_bracket_notation/036.phpt
+++ b/tests/comparison_bracket_notation/036.phpt
@@ -23,7 +23,7 @@ $result = $jsonPath->find($data, "$['two'.'some']");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 8 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Quoted node names must use the bracket notation `[` at position 8 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_bracket_notation/037.phpt
+++ b/tests/comparison_bracket_notation/037.phpt
@@ -22,7 +22,7 @@ $result = $jsonPath->find($data, "$[two.some]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unexpected filter element in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unexpected filter element in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_bracket_notation/046.phpt
+++ b/tests/comparison_bracket_notation/046.phpt
@@ -15,7 +15,7 @@ $result = $jsonPath->find($data, "$[key]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `k` at position 2 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `k` at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/003.phpt
+++ b/tests/comparison_dot_notation/003.phpt
@@ -20,7 +20,7 @@ $result = $jsonPath->find($data, "$.[key]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `k` at position 3 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `k` at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/022.phpt
+++ b/tests/comparison_dot_notation/022.phpt
@@ -16,7 +16,7 @@ $result = $jsonPath->find($data, '$."key"');
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 2 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Quoted node names must use the bracket notation `[` at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/023.phpt
+++ b/tests/comparison_dot_notation/023.phpt
@@ -34,7 +34,7 @@ $result = $jsonPath->find($data, '$.."key"');
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 3 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Quoted node names must use the bracket notation `[` at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/024.phpt
+++ b/tests/comparison_dot_notation/024.phpt
@@ -17,7 +17,7 @@ $result = $jsonPath->find($data, "$.");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Dot selector `.` must be followed by a node name or wildcard at position 1 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Dot selector `.` must be followed by a node name or wildcard at position 1 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/030.phpt
+++ b/tests/comparison_dot_notation/030.phpt
@@ -15,7 +15,7 @@ $result = $jsonPath->find($data, "$.$");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unexpected root `$` in node name, use bracket notation for node names with special characters in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unexpected root `$` in node name, use bracket notation for node names with special characters in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/035.phpt
+++ b/tests/comparison_dot_notation/035.phpt
@@ -16,7 +16,7 @@ $result = $jsonPath->find($data, "$.'key'");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 2 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Quoted node names must use the bracket notation `[` at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/036.phpt
+++ b/tests/comparison_dot_notation/036.phpt
@@ -34,7 +34,7 @@ $result = $jsonPath->find($data, "$..'key'");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 3 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Quoted node names must use the bracket notation `[` at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/037.phpt
+++ b/tests/comparison_dot_notation/037.phpt
@@ -19,7 +19,7 @@ $result = $jsonPath->find($data, "$.'some.key'");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation `[` at position 2 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Quoted node names must use the bracket notation `[` at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/038.phpt
+++ b/tests/comparison_dot_notation/038.phpt
@@ -18,7 +18,7 @@ $result = $jsonPath->find($data, "$. a");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unexpected whitespace at position 2 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unexpected whitespace at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/048.phpt
+++ b/tests/comparison_dot_notation/048.phpt
@@ -16,7 +16,7 @@ $result = $jsonPath->find($data, "\$a");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `a` at position 1 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `a` at position 1 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/049.phpt
+++ b/tests/comparison_dot_notation/049.phpt
@@ -15,7 +15,7 @@ $result = $jsonPath->find($data, ".key");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: JSONPath must start with a root operator `$` in %s
+Fatal error: Uncaught JsonPath\JsonPathException: JSONPath must start with a root operator `$` in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/050.phpt
+++ b/tests/comparison_dot_notation/050.phpt
@@ -15,7 +15,7 @@ $result = $jsonPath->find($data, "key");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `k` at position 0 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `k` at position 0 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/004.phpt
+++ b/tests/comparison_filter/004.phpt
@@ -29,7 +29,7 @@ $result = $jsonPath->find($data, "$[?(@.key+50==100)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `+` at position 9 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `+` at position 9 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/019.phpt
+++ b/tests/comparison_filter/019.phpt
@@ -29,7 +29,7 @@ $result = $jsonPath->find($data, "$[?(@.key/10==5)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing regex / at position 9 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Missing closing regex / at position 9 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/022.phpt
+++ b/tests/comparison_filter/022.phpt
@@ -20,7 +20,7 @@ $result = $jsonPath->find($data, "$[?()]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Expecting child node, filter, expression, or recursive node in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Expecting child node, filter, expression, or recursive node in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/029.phpt
+++ b/tests/comparison_filter/029.phpt
@@ -28,7 +28,7 @@ $result = $jsonPath->find($data, "$[?(@[0:1]==[1])]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unsupported expression operand in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unsupported expression operand in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/030.phpt
+++ b/tests/comparison_filter/030.phpt
@@ -36,7 +36,7 @@ $result = $jsonPath->find($data, "$[?(@.*==[1,2])]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unsupported expression operand in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unsupported expression operand in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/040.phpt
+++ b/tests/comparison_filter/040.phpt
@@ -64,7 +64,7 @@ $result = $jsonPath->find($data, "$[?(@.d=={\"k\":\"v\"})]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `{` at position 9 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `{` at position 9 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/049.phpt
+++ b/tests/comparison_filter/049.phpt
@@ -29,7 +29,7 @@ $result = $jsonPath->find($data, "$[?(@.d in [2, 3])]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `i` at position 8 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `i` at position 8 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/050.phpt
+++ b/tests/comparison_filter/050.phpt
@@ -43,7 +43,7 @@ $result = $jsonPath->find($data, "$[?(2 in @.d)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `i` at position 6 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `i` at position 6 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/053.phpt
+++ b/tests/comparison_filter/053.phpt
@@ -29,7 +29,7 @@ $result = $jsonPath->find($data, "$[?(@.key*2==100)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `*` at position 9 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `*` at position 9 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/061.phpt
+++ b/tests/comparison_filter/061.phpt
@@ -80,7 +80,7 @@ $result = $jsonPath->find($data, "$[?(@.key=42)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Invalid character after `=`, valid values are `==` and `=~` at position 10 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Invalid character after `=`, valid values are `==` and `=~` at position 10 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/066.phpt
+++ b/tests/comparison_filter/066.phpt
@@ -80,7 +80,7 @@ $result = $jsonPath->find($data, "$[?(@.key===42)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Invalid character after `=`, valid values are `==` and `=~` at position 12 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Invalid character after `=`, valid values are `==` and `=~` at position 12 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/070.phpt
+++ b/tests/comparison_filter/070.phpt
@@ -25,7 +25,7 @@ $result = $jsonPath->find($data, "$[?(false)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Invalid expression. in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Invalid expression. in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/072.phpt
+++ b/tests/comparison_filter/072.phpt
@@ -25,7 +25,7 @@ $result = $jsonPath->find($data, "$[?(null)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Invalid expression. in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Invalid expression. in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/073.phpt
+++ b/tests/comparison_filter/073.phpt
@@ -25,7 +25,7 @@ $result = $jsonPath->find($data, "$[?(true)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Invalid expression. in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Invalid expression. in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/074.phpt
+++ b/tests/comparison_filter/074.phpt
@@ -80,7 +80,7 @@ $result = $jsonPath->find($data, "$[?@.key==42]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing opening paren `(` in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Missing opening paren `(` in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_misc/001.phpt
+++ b/tests/comparison_misc/001.phpt
@@ -16,7 +16,7 @@ $result = $jsonPath->find($data, "");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: JSONPath must start with a root operator `$` in %s
+Fatal error: Uncaught JsonPath\JsonPathException: JSONPath must start with a root operator `$` in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_misc/002.phpt
+++ b/tests/comparison_misc/002.phpt
@@ -17,7 +17,7 @@ $result = $jsonPath->find($data, "$(key,more)");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `k` at position 2 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `k` at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_misc/003.phpt
+++ b/tests/comparison_misc/003.phpt
@@ -19,7 +19,7 @@ $result = $jsonPath->find($data, "$[(@.length-1)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unexpected filter element in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unexpected filter element in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_recursive_descent/001.phpt
+++ b/tests/comparison_recursive_descent/001.phpt
@@ -23,7 +23,7 @@ $result = $jsonPath->find($data, "$..");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard at position 3 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_recursive_descent/002.phpt
+++ b/tests/comparison_recursive_descent/002.phpt
@@ -22,7 +22,7 @@ $result = $jsonPath->find($data, "$.key..");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard at position 7 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Recursive descent operator `..` must be followed by a child selector, filter or wildcard at position 7 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_union/004.phpt
+++ b/tests/comparison_union/004.phpt
@@ -38,7 +38,7 @@ $result = $jsonPath->find($data, "$[?(@.key<3),?(@.key>6)]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Unrecognized token `?` at position 13 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Unrecognized token `?` at position 13 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_union/012.phpt
+++ b/tests/comparison_union/012.phpt
@@ -24,7 +24,7 @@ $result = $jsonPath->find($data, "$.*[0,:5]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Multiple filter list separators `,` and `:` found, only one type is allowed in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Multiple filter list separators `,` and `:` found, only one type is allowed in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_union/013.phpt
+++ b/tests/comparison_union/013.phpt
@@ -19,7 +19,7 @@ $result = $jsonPath->find($data, "$[1:3,4]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Multiple filter list separators `,` and `:` found, only one type is allowed in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Multiple filter list separators `,` and `:` found, only one type is allowed in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_union/015.phpt
+++ b/tests/comparison_union/015.phpt
@@ -19,7 +19,7 @@ $result = $jsonPath->find($data, "$[*,1]");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Wildcard filter contains an invalid character, expected `]` at position 3 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Wildcard filter contains an invalid character, expected `]` at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/lex_errs/001.phpt
+++ b/tests/lex_errs/001.phpt
@@ -9,7 +9,7 @@ $jsonPath = new \JsonPath\JsonPath();
 
 $jsonPath->find([], "$.testl['test'");
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Missing filter end `]` in %s
 Stack trace:
 %s
 %s

--- a/tests/lex_errs/002.phpt
+++ b/tests/lex_errs/002.phpt
@@ -9,7 +9,7 @@ $jsonPath = new \JsonPath\JsonPath();
 
 $jsonPath->find([], '$.testl["test"');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Missing filter end `]` in %s
 Stack trace:
 %s
 %s

--- a/tests/lex_errs/004.phpt
+++ b/tests/lex_errs/004.phpt
@@ -9,7 +9,7 @@ $jsonPath = new \JsonPath\JsonPath();
 
 $jsonPath->find([], '$.book[?(@.id.isbn == "684832674" & @.author == "Herman Melville")]');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: AND operator must be double ampersand `&&` at position 35 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: AND operator must be double ampersand `&&` at position 35 in %s
 Stack trace:
 %s
 %s

--- a/tests/lex_errs/005.phpt
+++ b/tests/lex_errs/005.phpt
@@ -9,7 +9,7 @@ $jsonPath = new \JsonPath\JsonPath();
 
 $jsonPath->find([], '$.book[?(@.id.isbn == "684832674" | @.author == "Herman Melville")]');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: OR operator must be double pipe `||` at position 35 in %s
+Fatal error: Uncaught JsonPath\JsonPathException: OR operator must be double pipe `||` at position 35 in %s
 Stack trace:
 %s
 %s

--- a/tests/parse_errs/001.phpt
+++ b/tests/parse_errs/001.phpt
@@ -9,7 +9,7 @@ $jsonPath = new \JsonPath\JsonPath();
 
 $jsonPath->find([], '$.book[');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing filter end `]` in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Missing filter end `]` in %s
 Stack trace:
 %s
 %s

--- a/tests/parse_errs/002.phpt
+++ b/tests/parse_errs/002.phpt
@@ -9,7 +9,7 @@ $jsonPath = new \JsonPath\JsonPath();
 
 $jsonPath->find([], '$.store.book[?(@.author == "Evelyn Waugh"');
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing paren `)` in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Missing closing paren `)` in %s
 Stack trace:
 %s
 %s

--- a/tests/regex/003.phpt
+++ b/tests/regex/003.phpt
@@ -22,7 +22,7 @@ var_dump($result);
 --EXPECTF--
 Warning: JsonPath\JsonPath::find(): Compilation failed: missing closing parenthesis at offset 13 in %s
 
-Fatal error: Uncaught RuntimeException: Invalid regex pattern `/invalid([a-]+/` in %s
+Fatal error: Uncaught JsonPath\JsonPathException: Invalid regex pattern `/invalid([a-]+/` in %s
 Stack trace:
 %s
 %s


### PR DESCRIPTION
This PR introduces a `JsonPathException` that is thrown on all occasions where we previously threw a `RuntimeException`. The logic is placed in `exceptions.c`, which allows easy re-use across the project using a `throw_jsonpath_exception()` function.

The arginfo generation now makes use of the recent (?) addition of `@generate-class-entries`. This slightly reduces the amount of boilerplate code in `jsonpath.c`. Instead we get the code auto-generated into the arginfo files based on the class definitions in the stub. Yay!