### PR TITLE
Replace strdup->estrdup

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -39,7 +39,7 @@ PHP_METHOD(JsonPath_JsonPath, find) {
 
   /* Keep the original parameter untouched for the stack trace and instead work with a copy that might be modified
    * during processing, e.g. due to escaped quotes in string literals */
-  char* j_path_work_copy = strdup(j_path);
+  char* j_path_work_copy = estrdup(j_path);
 
   /* tokenize JSON-path string */
 
@@ -49,7 +49,7 @@ PHP_METHOD(JsonPath_JsonPath, find) {
   bool scan_ok = scan_tokens(j_path_work_copy, lex_tok, &lex_tok_count);
 
   if (!scan_ok) {
-    free(j_path_work_copy);
+    efree(j_path_work_copy);
     return;
   }
 
@@ -64,7 +64,7 @@ PHP_METHOD(JsonPath_JsonPath, find) {
   struct ast_node* head = parse_jsonpath(lex_tok, &i, lex_tok_count, &pool);
 
   if (head == NULL) {
-    free(j_path_work_copy);
+    efree(j_path_work_copy);
     free_php_objects(&pool);
     return;
   }
@@ -79,7 +79,7 @@ PHP_METHOD(JsonPath_JsonPath, find) {
 
   eval_ast(search_target, search_target, head, return_value);
 
-  free(j_path_work_copy);
+  efree(j_path_work_copy);
   free_php_objects(&pool);
 
   /* return false if no results were found by the JSON-path query */


### PR DESCRIPTION
Use the Zend memory manager for allocating a copy of the jsonpath
string, as per the [PHP coding standards](https://raw.githubusercontent.com/php/php-src/master/CODING_STANDARDS.md).